### PR TITLE
Fix opend computation

### DIFF
--- a/omggif.js
+++ b/omggif.js
@@ -548,9 +548,11 @@ function GifReader(buf) {
     var framestride = width - framewidth;
     var xleft       = framewidth;  // Number of subrect pixels left in scanline.
 
-    // Output indicies of the top left and bottom right corners of the subrect.
+    // Output index of the top left corner of the subrect.
     var opbeg = ((frame.y * width) + frame.x) * 4;
-    var opend = ((frame.y + frame.height) * width - (width - frame.width - frame.x)) * 4;
+    // Output index of what would be the left edge of the subrect, one row below it,
+    // i.e. the index at which an interlace pass should wrap.
+    var opend = ((frame.y + frame.height) * width + frame.x) * 4;
     var op    = opbeg;
 
     var scanstride = framestride * 4;
@@ -614,9 +616,11 @@ function GifReader(buf) {
     var framestride = width - framewidth;
     var xleft       = framewidth;  // Number of subrect pixels left in scanline.
 
-    // Output indicies of the top left and bottom right corners of the subrect.
+    // Output index of the top left corner of the subrect.
     var opbeg = ((frame.y * width) + frame.x) * 4;
-    var opend = ((frame.y + frame.height) * width - (width - frame.width - frame.x)) * 4;
+    // Output index of what would be the left edge of the subrect, one row below it,
+    // i.e. the index at which an interlace pass should wrap.
+    var opend = ((frame.y + frame.height) * width + frame.x) * 4;
     var op    = opbeg;
 
     var scanstride = framestride * 4;

--- a/omggif.js
+++ b/omggif.js
@@ -550,7 +550,7 @@ function GifReader(buf) {
 
     // Output indicies of the top left and bottom right corners of the subrect.
     var opbeg = ((frame.y * width) + frame.x) * 4;
-    var opend = ((frame.y + frame.height) * width + frame.x) * 4;
+    var opend = ((frame.y + frame.height) * width - (width - frame.width - frame.x)) * 4;
     var op    = opbeg;
 
     var scanstride = framestride * 4;
@@ -616,7 +616,7 @@ function GifReader(buf) {
 
     // Output indicies of the top left and bottom right corners of the subrect.
     var opbeg = ((frame.y * width) + frame.x) * 4;
-    var opend = ((frame.y + frame.height) * width + frame.x) * 4;
+    var opend = ((frame.y + frame.height) * width - (width - frame.width - frame.x)) * 4;
     var op    = opbeg;
 
     var scanstride = framestride * 4;


### PR DESCRIPTION
This PR fixes a bug in the computation of `opend`. 

Currently `((frame.y + frame.height) * width + frame.x)` on any frame specified by a subrect smaller than the full GIF size will give the index of the pixel 1px _beneath_ the left edge of the subrect. Since the intention of `opend` is to be the "output index of the bottom right corner of the subrect," this should actually be something like `((frame.y + frame.height) * width (width - frame.width - frame.x))`, which would be the index of the pixel immediately following (one px after) the bottom right corner. In practice I don't think this would have caused many/any bugs for its use in interlaced GIFs, but I was fixing this in a fork because I needed an accurate `opend` for rendering pixels and figured I would fix it here :)

![image](https://user-images.githubusercontent.com/3170312/57161399-5af96700-6da0-11e9-9887-44620b7a5d55.png)

("Output index of the bottom right corner of the subrect" could be interpreted as the px _inside_ the subrect — the result of this change minus an additional `1` — but since it's used in a `>=` operator below, this seemed more fitting.)