### PR TITLE
Skip plain text blocks

### DIFF
--- a/omggif.js
+++ b/omggif.js
@@ -443,6 +443,9 @@ function GifReader(buf) {
             p++;  // Skip terminator.
             break;
 
+          case 0x01:  // Plain Text Extension: unimplemented.
+            // Basically no GIF renderers support this, but it is
+            // technically a valid block. Seek past it.
           case 0xfe:  // Comment Extension.
             while (true) {  // Seek through subblocks.
               var block_size = buf[p++];


### PR DESCRIPTION
This PR adds a case for reading (or specifically, skipping) plain text blocks. Plain text is a valid GIF extension in GIF89a (search "0x01" in https://www.w3.org/Graphics/GIF/spec-gif89a.txt). No modern browsers render plain text as intended (see [link](http://ata4.github.io/gifiddle/#http://www.olsenhome.com/gif/BOB_89A.GIF) for the intended rendering of [this GIF](http://www.olsenhome.com/gif/BOB_89A.GIF) created by/of Bob Berry to demonstrate new features of 89a). But it is technically a valid extension label, so a decoder should not throw an error on encountering it.